### PR TITLE
sound@cinnamon.org: fix refreshing of track cover

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -724,8 +724,12 @@ class Player extends PopupMenu.PopupMenuSection {
                 let cover_path = "";
                 if (this._trackCoverFile.match(/^http/)) {
                     this._hideCover();
-                    if(!this._trackCoverFileTmp)
-                        this._trackCoverFileTmp = Gio.file_new_tmp('XXXXXX.mediaplayer-cover')[0];
+
+                    if (this._trackCoverFileTmp && this._trackCoverFileTmp.query_exists(null)) {
+                        this._trackCoverFileTmp.delete(null);
+                    }
+
+                    this._trackCoverFileTmp = Gio.file_new_tmp('XXXXXX.mediaplayer-cover')[0];
                     Util.spawn_async(['wget', this._trackCoverFile, '-O', this._trackCoverFileTmp.get_path()], Lang.bind(this, this._onDownloadedCover));
                 }
                 else {


### PR DESCRIPTION
When using an audio player which fetches it's track covers over http (e.g. Spotify), the first cover will be set, but then it never gets updated.

The current implementation creates a temp file once and always overwrites it when the cover changes.
Although the file is correctly downloaded, the name of the temp file stays the same.  
This leads to a situation where the first set cover is cached somewhere and is no longer updated afterwards.

The cached icon comes either from `Gio.file_new_for_path` or from `new Gio.FileIcon` in [this file](https://github.com/linuxmint/cinnamon/blob/b11f9ed4769842d4a923ce939bf1dead725084a0/js/ui/applet.js#L724-L725). I couldn't track that down further.

To overcome this issue, I always create a new temp file with a new name. If one was created before, this old file will be deleted first.